### PR TITLE
Patch/ci cd docker pull

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -224,7 +224,7 @@ jobs:
             chmod 644 certs/cert.pem
 
             # 登录 GitHub Container Registry
-            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
             # 设置镜像标签并拉取启动容器
             export TAG=dev
@@ -310,7 +310,7 @@ jobs:
             chmod 644 certs/cert.pem
 
             # 登录 GitHub Container Registry
-            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
             # 设置镜像标签并拉取启动容器
             export TAG=main


### PR DESCRIPTION
更新了 `.github/workflows/cd.yml` 中的部署工作流，以确保在拉取 Docker 镜像之前对 GitHub 容器注册表进行身份验证。
主要更改是在设置镜像标签和启动容器之前，使用 GitHub 密钥添加了 Docker 登录步骤。