### PR TITLE
Fix/frontend/admin reports

### DIFF
--- a/frontend-web/src/views/ReportManage.vue
+++ b/frontend-web/src/views/ReportManage.vue
@@ -464,10 +464,10 @@ export default defineComponent({
       }
 
       try {
-        const response = await reviewApi.deleteReview(report.targetId)
+        const response = await reviewApi.handleReport(report.id, { action: 'delete_content' })
         if (response.code === 200) {
           alert('删除成功')
-          loadReports()
+          await loadReports()
           // 如果详情对话框打开，更新选中的举报信息
           if (selectedReport.value && selectedReport.value.id === report.id) {
             // 重新加载该举报的详细信息
@@ -498,10 +498,10 @@ export default defineComponent({
       }
 
       try {
-        const response = await reviewApi.deleteComment(report.targetId)
+        const response = await reviewApi.handleReport(report.id, { action: 'delete_content' })
         if (response.code === 200) {
           alert('删除成功')
-          loadReports()
+          await loadReports()
           // 如果详情对话框打开，更新选中的举报信息
           if (selectedReport.value && selectedReport.value.id === report.id) {
             // 重新加载该举报的详细信息
@@ -555,7 +555,7 @@ export default defineComponent({
 
         if (response.code === 200) {
           alert('处理成功')
-          loadReports()
+          await loadReports()
           // 如果详情对话框打开，更新选中的举报信息
           if (selectedReport.value && selectedReport.value.id === report.id) {
             // 重新加载该举报的详细信息


### PR DESCRIPTION
此拉取请求更新了 `ReportManage.vue` 组件中处理举报的方式，采用统一的 API 方法来删除被举报内容，并确保在操作完成后刷新举报列表。

API 集成改进：

* 将独立的 API 调用（`deleteReview` 和 `deleteComment`）替换为统一的 `handleReport` 方法，通过传递举报 ID 和动作参数来删除被举报内容。这简化了代码并集中了举报处理逻辑。

UX 改进：

* 更新了举报操作后对 `loadReports()` 的所有调用，改为使用 `await`，确保只有在收到 API 响应后才刷新举报列表，从而提高了 UI 的一致性。