### PR TITLE
Feature/backend/batchadd

### DIFF
--- a/backend/src/admin-dishes/admin-dishes.service.ts
+++ b/backend/src/admin-dishes/admin-dishes.service.ts
@@ -1281,6 +1281,22 @@ export class AdminDishesService {
           status: 'online',
         },
       });
+    } else {
+      parentDish = await tx.dish.update({
+        where: { id: parentDish.id },
+        data: {
+          description: description || '',
+          tags,
+          ingredients,
+          allergens,
+          availableMealTime: mealTimes,
+          availableDates,
+          floorId: floor?.id,
+          floorLevel: floor?.level,
+          floorName: floor?.name,
+          windowNumber: window.number,
+        },
+      });
     }
 
     caches.parentDishes.set(key, parentDish);


### PR DESCRIPTION
在 `AdminDishesService` 类中，添加了一个新的逻辑分支，用于在特定条件下更新父菜品的详细信息。该功能涉及更新菜品的描述、标签、成分、过敏原、可用餐时间、可用日期以及楼层和窗口的相关信息。

具体修改内容如下：
- 当某种条件不满足时，通过 `tx.dish.update` 方法更新父菜品的信息。
- 更新的数据字段包括 `description`、`tags`、`ingredients`、`allergens`、`availableMealTime`、`availableDates`、`floorId`、`floorLevel`、`floorName` 和 `windowNumber`。